### PR TITLE
Change system language for correct install

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 - id: remove-comments
   name: Remove comments from scriv .md files
   entry: remove-comments
-  language: system
+  language: python
   types: [markdown]
   files: ^changelog\.d/.*\.md$


### PR DESCRIPTION
Needs to set `language=python` to tell `pre-commit` to install it as a python package